### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=id">Bahasa Indonesia</a>
+        | <a href="https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=as">অসমীয়া</
+      </div>
+    </div>
+  </details>
+</div>
+
 # Parse Partial JSON Stream - Turn your slow AI app into an engaging real-time app
 
 - Convert a **stream of token** into a **parsable JSON** object before the stream ends.


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search, and it's open source project, we can change web or local file mode.

The updated links can be previewed in my forked repository: https://github.com/openaitx-system/openai-partial-stream/tree/Auto_translate_README_and_Wiki

Demo links : 
- [Español](https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=es)
- [简体中文](https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=ko)
- [Français](https://openaitx.github.io/view.html?user=st3w4r&project=openai-partial-stream&lang=fr)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962  " />

If this doesn't align with your expectations, feel free to close this PR. Thanks for your time! 🙌
